### PR TITLE
Ability to hide user secrets using SecretsManager tool and Configuration API

### DIFF
--- a/src/JabbR-Core/Controllers/HomeController.cs
+++ b/src/JabbR-Core/Controllers/HomeController.cs
@@ -17,8 +17,6 @@ namespace JabbR_Core.Controllers
 {
     public class HomeController : Controller
     {
-        IConfigurationRoot Configure { get; }
-
         [HttpGet("/")]
         public IActionResult Index()
         {
@@ -36,7 +34,6 @@ namespace JabbR_Core.Controllers
                 //MaxMessageLength = settings.MaxMessageLength,
                 //AllowRoomCreation = settings.AllowRoomCreation || Principal.HasClaim(JabbRClaimTypes.Admin)
             };
-
 
             return View(viewModel);
         }

--- a/src/JabbR-Core/Controllers/HomeController.cs
+++ b/src/JabbR-Core/Controllers/HomeController.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.Mvc;
 using JabbR_Core.ViewModels;
 using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.VisualBasic;
+using JabbR_Core;
+using Microsoft.Extensions.Configuration;
 
 // For more information on enabling MVC for empty projects, visit http://go.microsoft.com/fwlink/?LinkID=397860
 
@@ -15,10 +17,14 @@ namespace JabbR_Core.Controllers
 {
     public class HomeController : Controller
     {
+        IConfigurationRoot Configure { get; }
 
         [HttpGet("/")]
         public IActionResult Index()
         {
+
+            string key = Configure["db"];
+
             var viewModel = new SettingsViewModel
             {
                 //GoogleAnalytics = settings.GoogleAnalytics,

--- a/src/JabbR-Core/Controllers/HomeController.cs
+++ b/src/JabbR-Core/Controllers/HomeController.cs
@@ -22,9 +22,6 @@ namespace JabbR_Core.Controllers
         [HttpGet("/")]
         public IActionResult Index()
         {
-
-            string key = Configure["db"];
-
             var viewModel = new SettingsViewModel
             {
                 //GoogleAnalytics = settings.GoogleAnalytics,

--- a/src/JabbR-Core/Startup.cs
+++ b/src/JabbR-Core/Startup.cs
@@ -31,14 +31,14 @@ namespace JabbR_Core
         // For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            // Use `dotnet user-secrets set db dbpassword` to save the passsword as an env variable
-            // on your machine. Most of the connection string can exist as plain text, so you can 
-            // do this for your login information and format that into your connection string, as below.
+            // Use `dotnet user-secrets set key value` to save as an env variable
+            // on your machine.
             //
-            // var user = Configuration["db-user"];
-            // var pass = Configuration["db-pass"];
+            // Store the connection string using the CLI tool. Include your actual username and password
+            // >dotnet user-secrets set connectionString $"Server=MYAPPNAME.database.windows.net,1433;Initial Catalog=MYCATALOG;Persist Security Info=False;User ID={user};Password={pass};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;";
             // 
-            // var connectionString = $"Server=MYAPPNAME.database.windows.net,1433;Initial Catalog=MYCATALOG;Persist Security Info=False;User ID={user};Password={pass};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;";
+            // Reference the Configuration API with the key you defined, and your env variable will be referenced.
+            // var connectionString = Configuration["connectionString"];
             // services.AddDbContext<MyContext>(options => options.UseSqlServer(connectionString));
 
             services.AddMvc();

--- a/src/JabbR-Core/Startup.cs
+++ b/src/JabbR-Core/Startup.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace JabbR_Core
 {

--- a/src/JabbR-Core/Startup.cs
+++ b/src/JabbR-Core/Startup.cs
@@ -23,7 +23,7 @@ namespace JabbR_Core
             }
 
             builder.AddEnvironmentVariables();
-
+            
             Configuration = builder.Build();
         }
 
@@ -31,6 +31,7 @@ namespace JabbR_Core
         // For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
+            var thing = Configuration["db"];
             services.AddMvc();
             services.AddSignalR();
         }

--- a/src/JabbR-Core/Startup.cs
+++ b/src/JabbR-Core/Startup.cs
@@ -35,7 +35,7 @@ namespace JabbR_Core
             // on your machine.
             //
             // Store the connection string using the CLI tool. Include your actual username and password
-            // >dotnet user-secrets set connectionString $"Server=MYAPPNAME.database.windows.net,1433;Initial Catalog=MYCATALOG;Persist Security Info=False;User ID={user};Password={pass};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;";
+            // >dotnet user-secrets set "connectionString" "Server=MYAPPNAME.database.windows.net,1433;Initial Catalog=MYCATALOG;Persist Security Info=False;User ID={plaintext user};Password={plaintext pass};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;"
             // 
             // Reference the Configuration API with the key you defined, and your env variable will be referenced.
             // var connectionString = Configuration["connectionString"];

--- a/src/JabbR-Core/Startup.cs
+++ b/src/JabbR-Core/Startup.cs
@@ -31,9 +31,21 @@ namespace JabbR_Core
         // For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-            var thing = Configuration["db"];
+
+            // Use `dotnet user-secrets set db dbpassword` to save the passsword as an env variable
+            // on your machine. Most of the connection string can exist as plain text, so you can 
+            // do this for your login information and format that into your connection string, as below.
+            //
+            // var user = Configuration["db-user"];
+            // var pass = Configuration["db-pass"];
+            // 
+            // var connectionString = $"Server=MYAPPNAME.database.windows.net,1433;Initial Catalog=MYCATALOG;Persist Security Info=False;User ID={user};Password={pass};MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;";
+            // services.AddDbContext<MyContext>(options => options.UseSqlServer(connectionString));
+
             services.AddMvc();
             services.AddSignalR();
+
+
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/JabbR-Core/Startup.cs
+++ b/src/JabbR-Core/Startup.cs
@@ -8,6 +8,25 @@ namespace JabbR_Core
 {
     public class Startup
     {
+        public IConfigurationRoot Configuration { get; }
+
+        public Startup(IHostingEnvironment env)
+        {
+            var builder = new ConfigurationBuilder()
+                .SetBasePath(env.ContentRootPath)
+                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
+
+            if(env.IsDevelopment())
+            {
+                builder.AddUserSecrets();
+            }
+
+            builder.AddEnvironmentVariables();
+
+            Configuration = builder.Build();
+        }
+
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)

--- a/src/JabbR-Core/Startup.cs
+++ b/src/JabbR-Core/Startup.cs
@@ -31,7 +31,6 @@ namespace JabbR_Core
         // For more information on how to configure your application, visit http://go.microsoft.com/fwlink/?LinkID=398940
         public void ConfigureServices(IServiceCollection services)
         {
-
             // Use `dotnet user-secrets set db dbpassword` to save the passsword as an env variable
             // on your machine. Most of the connection string can exist as plain text, so you can 
             // do this for your login information and format that into your connection string, as below.
@@ -44,8 +43,6 @@ namespace JabbR_Core
 
             services.AddMvc();
             services.AddSignalR();
-
-
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/JabbR-Core/appsettings.json
+++ b/src/JabbR-Core/appsettings.json
@@ -11,7 +11,7 @@
     }
   },
   "Data": {
-    "ConnectionStrings": {
+    "ConnectionStrings": { 
       "DefaultConnection": ""
     }
   }

--- a/src/JabbR-Core/appsettings.json
+++ b/src/JabbR-Core/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "ApplicationInsights": {
+    "InstrumentationKey": "e502aa88-7410-450e-8fdf-45c070be8774"
+  },
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Debug",
+      "System": "Information",
+      "Microsoft": "Information"
+    }
+  },
+  "Data": {
+    "ConnectionStrings": {
+      "DefaultConnection": ""
+    }
+  }
+}

--- a/src/JabbR-Core/project.json
+++ b/src/JabbR-Core/project.json
@@ -1,4 +1,5 @@
 {
+  "userSecretsId": "aspnet-WebApp1-c23d27a4-eb88-4b18-9b77-2a93f3b15119",
   "dependencies": {
     "Microsoft.NETCore.App": {
       "version": "1.0.0",
@@ -10,11 +11,13 @@
     "Microsoft.AspNetCore.Server.Kestrel": "1.0.0",
     "Microsoft.Extensions.Logging.Console": "1.0.0",
     "Microsoft.AspNetCore.Mvc": "1.0.0",
-    "Microsoft.AspNetCore.StaticFiles": "1.0.0"
+    "Microsoft.AspNetCore.StaticFiles": "1.0.0",
+    "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0"
   },
 
   "tools": {
-    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final"
+    "Microsoft.AspNetCore.Server.IISIntegration.Tools": "1.0.0-preview2-final",
+    "Microsoft.Extensions.SecretManager.Tools": "1.0.0-preview2-final"
   },
 
   "frameworks": {


### PR DESCRIPTION
See issue #19 on hiding user secrets for more thorough explanation on using `dotnet user-secrets` to store and manage privacy in development. 

An example Configuration call has been shown in `Startup.cs` as well, but it's all commented out because we don't have a database on JabbR_Core yet (except LocalDB), so no secrets need to be stored.