### PR TITLE
adding Views folder to publish options

### DIFF
--- a/src/JabbR-Core/project.json
+++ b/src/JabbR-Core/project.json
@@ -49,6 +49,7 @@
   "publishOptions": {
     "include": [
       "wwwroot",
+      "Views",
       "web.config"
     ]
   },


### PR DESCRIPTION
This resolves issue #70 

Ran `dotnet publish` and verified that the Views folder was successfully output with the other publish files. Should be good to go.