### PR TITLE
Gabby/AddOwnerCommand

### DIFF
--- a/src/JabbR-Core/Commands/AddOwnerCommand.cs
+++ b/src/JabbR-Core/Commands/AddOwnerCommand.cs
@@ -1,0 +1,37 @@
+using System;
+using JabbR_Core.Models;
+using Microsoft.AspNetCore.SignalR;
+
+namespace JabbR_Core.Commands
+{
+    [Command("addowner", "AddOwner_CommandInfo", "user [room]", "room")]
+    public class AddOwnerCommand : UserCommand
+    {
+        public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
+        {
+            if (args.Length == 0)
+            {
+                throw new HubException(LanguageResources.AddOwner_UserRequired);
+            }
+
+            string targetUserName = args[0];
+
+            ChatUser targetUser = context.Repository.VerifyUser(targetUserName);
+
+            string roomName = args.Length > 1 ? args[1] : callerContext.RoomName;
+
+            if (String.IsNullOrEmpty(roomName))
+            {
+                throw new HubException(LanguageResources.AddOwner_RoomRequired);
+            }
+
+            ChatRoom targetRoom = context.Repository.VerifyRoom(roomName);
+
+            context.Service.AddOwner(callingUser, targetUser, targetRoom);
+
+            context.NotificationService.AddOwner(targetUser, targetRoom);
+
+            context.Repository.CommitChanges();
+        }
+    }
+}

--- a/src/JabbR-Core/Commands/CommandManager.cs
+++ b/src/JabbR-Core/Commands/CommandManager.cs
@@ -184,16 +184,16 @@ namespace JabbR_Core.Commands
         public static IList<ICommand> GetCommands()
         {
             
-            IEnumerable<ICommand> commandsList = typeof(CommandManager).GetType().GetTypeInfo().Assembly.GetExportedTypes()
+          /*  IEnumerable<ICommand> commandsList = typeof(CommandManager).GetType().GetTypeInfo().Assembly.GetExportedTypes()
                 .Where(t => t.GetType().GetTypeInfo().IsSubclassOf(typeof(ICommand)))
                 .Select(t => (ICommand)Activator.CreateInstance(t));
-            return commandsList.ToList();
+            return commandsList.ToList();*/
           
             // Use MEF to locate the content providers in this assembly
             //var catalog = new AssemblyCatalog(typeof(CommandManager).Assembly);
             //var compositionContainer = new CompositionContainer(catalog);
             //return compositionContainer.GetExportedValues<ICommand>().ToList();
-            //return new List<ICommand>() { new JoinCommand(), new OpenCommand(), new CreateCommand(), new LeaveCommand(), new CloseCommand() };
+            return new List<ICommand>() { new JoinCommand(), new OpenCommand(), new CreateCommand(), new LeaveCommand(), new CloseCommand(), new AddOwnerCommand() };
         }
 
         public static IEnumerable<CommandMetaData> GetCommandsMetaData()

--- a/src/JabbR-Core/Services/InMemoryRepository.cs
+++ b/src/JabbR-Core/Services/InMemoryRepository.cs
@@ -50,7 +50,19 @@ namespace JabbR_Core.Services
                 Status = 1
             };
             _users.Add(user);
-            
+
+            //created a new user for testing AddOwner commands
+            var user2 = new ChatUser
+            {
+                Id = "2",
+                Name = "Jack",
+                LastActivity = Convert.ToDateTime("2016-08-23 00:26:35.713"),
+                IsAdmin = true,
+                IsAfk = true,
+                Status = 1
+            };
+            _users.Add(user2);
+
 
             ChatClient = new ChatClient
             {
@@ -68,7 +80,7 @@ namespace JabbR_Core.Services
             UserModel = new UserViewModel(user);
 
             // populate ChatRoom and RoomList
-            var room = new ChatRoom { Name = "light_meow" };
+            var room = new ChatRoom { Name = "light_meow", Users = _users };
             RoomList = new List<ChatRoom> { room };
 
             RoomViewModel = new RoomViewModel();


### PR DESCRIPTION
The  Add Owner command is used in the chatroom to make a Jabbr user an Owner of that room.. To test you should be able to click into light meow and in the textbox type /addowner [username] and it should return "[username] is now an owner of light_meow". If you put a username that does not exist, it should return " Unable to find [username]"