### PR TITLE
Kevin/admincommand

### DIFF
--- a/src/JabbR-Core/Commands/AdminCommand.cs
+++ b/src/JabbR-Core/Commands/AdminCommand.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using JabbR_Core.Data.Models;
+using Microsoft.AspNetCore.SignalR;
+
+namespace JabbR_Core.Commands
+{
+    public abstract class AdminCommand : UserCommand
+    {
+        public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
+        {
+            if (!callingUser.IsAdmin)
+            {
+                throw new HubException(LanguageResources.AdminRequired);
+            }
+
+            ExecuteAdminOperation(context, callerContext, callingUser, args);
+        }
+
+        public abstract void ExecuteAdminOperation(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args);
+    }
+}

--- a/src/JabbR-Core/Commands/BroadcastCommand.cs
+++ b/src/JabbR-Core/Commands/BroadcastCommand.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using JabbR_Core.Data.Models;
+using Microsoft.AspNetCore.SignalR;
+
+namespace JabbR_Core.Commands
+{
+    [Command("broadcast", "Broadcast_CommandInfo", "message", "global")]
+    public class BroadcastCommand : AdminCommand
+    {
+        public override void ExecuteAdminOperation(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
+        {
+            string messageText = String.Join(" ", args).Trim();
+
+            if (String.IsNullOrEmpty(messageText))
+            {
+                throw new HubException(LanguageResources.Broadcast_MessageRequired);
+            }
+
+            context.NotificationService.BroadcastMessage(callingUser, messageText);
+        }
+    }
+}

--- a/src/JabbR-Core/Commands/CommandManager.cs
+++ b/src/JabbR-Core/Commands/CommandManager.cs
@@ -181,7 +181,8 @@ namespace JabbR_Core.Commands
         public static IList<ICommand> GetCommands()
         {
            IEnumerable<ICommand> commandsList = typeof(CommandManager).GetTypeInfo().Assembly.GetExportedTypes()
-                .Where(o => o.GetTypeInfo().IsSubclassOf(typeof(UserCommand)))
+                .Where(o => o.GetTypeInfo().IsSubclassOf(typeof(UserCommand)) || o.GetTypeInfo().IsSubclassOf(typeof(AdminCommand)))
+                .Where(y => !y.GetTypeInfo().IsAbstract)
                 .Select(t => (ICommand)Activator.CreateInstance(t));
 
             return commandsList.ToList();

--- a/src/JabbR-Core/Commands/CommandManager.cs
+++ b/src/JabbR-Core/Commands/CommandManager.cs
@@ -180,12 +180,11 @@ namespace JabbR_Core.Commands
 
         public static IList<ICommand> GetCommands()
         {
-
            IEnumerable<ICommand> commandsList = typeof(CommandManager).GetTypeInfo().Assembly.GetExportedTypes()
                 .Where(o => o.GetTypeInfo().IsSubclassOf(typeof(UserCommand)))
                 .Select(t => (ICommand)Activator.CreateInstance(t));
-            return commandsList.ToList();
 
+            return commandsList.ToList();
         }
 
         public static IEnumerable<CommandMetaData> GetCommandsMetaData()


### PR DESCRIPTION
- AdminCommand.cs brought over.
- Command Manager GetCommands modified so that it does not attempt to create an instance of an abstract class (AdminCommand)
- @heatherbshapiro's /addadmin and /removeadmin can be tested in this branch
- BroadcastCommand brought over and implemented.

**Testing Use Cases**
1. Open SQL Server Object Explorer > (localdb)\ > Databases > JabbREFTest > dbo.AspNetUsers > ViewData (right click)
2. Find a user you would like to make an admin
3. Change the IsAdmin value from 'False' to 'True'
4. Update the database (top left refresh button) to ensure the change has been accepted.
5. Start the project
6. Start two browsers running JabbR and log in with the admin and one nonadmin use

Admin = userA
nonAdmin = userB
**Test /addadmin and /removeadmin**
7a. With userA, run '/addadmin <userB>'
8a. UI should show the changes made.
9a. Look at the database ViewData table and refresh the table.
10a. Ensure that the userB's 'IsAdmin' value is now 'True'
11a. With userB, run '/removeadmin <userA>'  (Admins can remove other admins)
12a. Check the database again and ensure the changes are reflected
13a. Try different variations of this and try to break the logic.

**Test /broadcast**
7b. With any admin user, run '/broadcast Broadcast test message!!' 
8b. Regardless of which chatroom other users are in, they should see this broadcast (Admin or not)

thanks.

