### PR TITLE
Gabby/notification mark as read

### DIFF
--- a/src/JabbR-Core/Controllers/NotificationController.cs
+++ b/src/JabbR-Core/Controllers/NotificationController.cs
@@ -54,7 +54,7 @@ namespace JabbR_Core.Controllers
                 return this.Redirect("~/Account/Login/");
             }
 
-            var request = new NotificationRequestModel(); 
+            var request = new NotificationRequestModel();
 
             var id = _context.HttpContext.User.GetUserId();
             ChatUser user = _repository.GetUserById(id);
@@ -74,107 +74,105 @@ namespace JabbR_Core.Controllers
         }
 
 
-        /*    [HttpPost]
-            public IActionResult MarkAsRead()//(int num)
-            {
+        [HttpPost]
+        public IActionResult MarkAsRead()//(int num)
+        {
 
-                /*  if (!IsAuthenticated)
+            if (!User.Identity.IsAuthenticated)
+            {
+                // return Forbidden view
+                Response.StatusCode = 403; // HttpStatusCode.Forbidden
+                //return this.Redirect("~/Account/Forbidden/");
+                return this.Redirect("~/Account/Login/");
+            }
+
+          /*  int notificationId = Request.Form.notificationId;
+
+            Notification notification = repository.GetNotificationById(notificationId);
+
+            if (notification == null)
+            {
+                return HttpStatusCode.NotFound;
+            }
+
+            ChatUser user = repository.GetUserById(Principal.GetUserId());
+
+            if (notification.UserKey != user.Key)
+            {
+                return HttpStatusCode.Forbidden;
+            }
+
+            notification.Read = true;
+            //      _repository.CommitChanges();
+
+            UpdateUnreadCountInChat(_repository, notificationService, user);
+
+            //    var response = Response.AsJson(new { success = true });
+
+            // return response;*/
+            return View("index");
+        }
+
+        /*  [HttpPost]
+          public IActionResult MarkAllAsRead()
+          {
+                  if (!IsAuthenticated)
                   {
                       return HttpStatusCode.Forbidden;
                   }
 
-                  int notificationId = Request.Form.notificationId;
+                  ChatUser user = repository.GetUserById(Principal.GetUserId());
+                  IList<Notification> unReadNotifications = repository.GetNotificationsByUser(user).Unread().ToList();
 
-                  Notification notification = repository.GetNotificationById(notificationId);
-
-                  if (notification == null)
+                  if (!unReadNotifications.Any())
                   {
                       return HttpStatusCode.NotFound;
                   }
 
-                  ChatUser user = repository.GetUserById(Principal.GetUserId());
-
-                  if (notification.UserKey != user.Key)
+                  foreach (var notification in unReadNotifications)
                   {
-                      return HttpStatusCode.Forbidden;
+                      notification.Read = true;
                   }
-                ChatUser user = _repository.GetUserById("1");
 
-                int notificationId = 1;//id;
+                  repository.CommitChanges();
 
-                Notification notification = _repository.GetNotificationById(notificationId);
+                  UpdateUnreadCountInChat(repository, notificationService, user);
 
-                notification.Read = true;
-                //      _repository.CommitChanges();
+                  var response = Response.AsJson(new { success = true });
 
-                UpdateUnreadCountInChat(_repository, notificationService, user);
+                  return response;
+              };
 
-                //    var response = Response.AsJson(new { success = true });
+              ChatUser user = _repository.GetUserById("1");
+              IList<Notification> unReadNotifications = _repository.GetNotificationsByUser(user).Unread().ToList();
 
-                // return response;
-                return View("index");
-            }
+              foreach (var notification in unReadNotifications)
+              {
+                  notification.Read = true;
+              }
 
-            [HttpPost]
-            public IActionResult MarkAllAsRead()
-            {/*
-                    if (!IsAuthenticated)
-                    {
-                        return HttpStatusCode.Forbidden;
-                    }
+              repository.CommitChanges();
 
-                    ChatUser user = repository.GetUserById(Principal.GetUserId());
-                    IList<Notification> unReadNotifications = repository.GetNotificationsByUser(user).Unread().ToList();
+              UpdateUnreadCountInChat(_repository, notificationService, user);
 
-                    if (!unReadNotifications.Any())
-                    {
-                        return HttpStatusCode.NotFound;
-                    }
+              //added this
+              var viewModel = new NotificationsViewModel
+              {
+                  ShowAll = false,//request.All
+                  UnreadCount = 0,
+                  //  TotalCount = 2, //was not here
+                  Notifications = null //notifications
+              };
 
-                    foreach (var notification in unReadNotifications)
-                    {
-                        notification.Read = true;
-                    }
+              return View("index", viewModel);
+          }
 
-                    repository.CommitChanges();
-
-                    UpdateUnreadCountInChat(repository, notificationService, user);
-
-                    var response = Response.AsJson(new { success = true });
-
-                    return response;
-                };
-
-                ChatUser user = _repository.GetUserById("1");
-                IList<Notification> unReadNotifications = _repository.GetNotificationsByUser(user).Unread().ToList();
-
-                foreach (var notification in unReadNotifications)
-                {
-                    notification.Read = true;
-                }
-
-                repository.CommitChanges();
-
-                UpdateUnreadCountInChat(_repository, notificationService, user);
-
-                //added this
-                var viewModel = new NotificationsViewModel
-                {
-                    ShowAll = false,//request.All
-                    UnreadCount = 0,
-                    //  TotalCount = 2, //was not here
-                    Notifications = null //notifications
-                };
-
-                return View("index", viewModel);
-            }
-
-            private static void UpdateUnreadCountInChat(InMemoryRepository repository, IChatNotificationService notificationService,
-                                                        ChatUser user)
-            {
-                var unread = repository.GetUnreadNotificationsCount(user);
-                notificationService.UpdateUnreadMentions(user, unread);
-            }*/
+          private static void UpdateUnreadCountInChat(InMemoryRepository repository, IChatNotificationService notificationService,
+                                                      ChatUser user)
+          {
+              var unread = repository.GetUnreadNotificationsCount(user);
+              notificationService.UpdateUnreadMentions(user, unread);
+          }*/
 
         private static List<NotificationViewModel> GetNotifications(IJabbrRepository repository, ChatUser user, bool all = false,
                                                                           int page = 1, int take = 20, string roomName = "light_meow")
@@ -198,52 +196,52 @@ namespace JabbR_Core.Controllers
 
 
 
-             return notificationsQuery.OrderByDescending(n => n.MessageKeyNavigation.When)
-                                      .Select(n => new NotificationViewModel()
-                                      {
-                                          NotificationKey = n.Key,
-                                          FromUserName = n.MessageKeyNavigation.UserKeyNavigation.Name,
-                                          FromUserImage = "Image", //n.Message.User.Hash,
+            return notificationsQuery.OrderByDescending(n => n.MessageKeyNavigation.When)
+                                     .Select(n => new NotificationViewModel()
+                                     {
+                                         NotificationKey = n.Key,
+                                         FromUserName = n.MessageKeyNavigation.UserKeyNavigation.Name,
+                                         FromUserImage = "Image", //n.Message.User.Hash,
                                           Message = n.MessageKeyNavigation.Content,
-                                          HtmlEncoded = n.MessageKeyNavigation.HtmlEncoded,
-                                          RoomName = n.RoomKeyNavigation.Name,
-                                          Read = n.Read,
-                                          When = n.MessageKeyNavigation.When
-                                      })
-                                      .ToList();
+                                         HtmlEncoded = n.MessageKeyNavigation.HtmlEncoded,
+                                         RoomName = n.RoomKeyNavigation.Name,
+                                         Read = n.Read,
+                                         When = n.MessageKeyNavigation.When
+                                     })
+                                     .ToList();
 
             //To test comment out the first return statement and uncomment the one below, so you have dummy notifications. For testing index
             //You should just be seeing the difference between Unread Notifications and All Notifications Tab. No functionality in this branch
 
-         /*   var vm = new NotificationViewModel()
-            {
-                NotificationKey = 1,
-                FromUserName = "Jack",
-                FromUserImage = "Image",
-                Message = "This is the unread test message",
-                HtmlEncoded = true,
-                RoomName = "light-meow",
-                Read = false,
-                When = DateTimeOffset.Now
-            };
+            /*   var vm = new NotificationViewModel()
+               {
+                   NotificationKey = 1,
+                   FromUserName = "Jack",
+                   FromUserImage = "Image",
+                   Message = "This is the unread test message",
+                   HtmlEncoded = true,
+                   RoomName = "light-meow",
+                   Read = false,
+                   When = DateTimeOffset.Now
+               };
 
-            var vm2 = new NotificationViewModel()
-            {
-                NotificationKey = 2,
-                FromUserName = "Jack",
-                FromUserImage = "Image",
-                Message = "This is the read test message ",
-                HtmlEncoded = true,
-                RoomName = "light-meow",
-                Read = true,
-                When = DateTimeOffset.Now
-            };
-            List<NotificationViewModel> notifications = new List<NotificationViewModel>();
+               var vm2 = new NotificationViewModel()
+               {
+                   NotificationKey = 2,
+                   FromUserName = "Jack",
+                   FromUserImage = "Image",
+                   Message = "This is the read test message ",
+                   HtmlEncoded = true,
+                   RoomName = "light-meow",
+                   Read = true,
+                   When = DateTimeOffset.Now
+               };
+               List<NotificationViewModel> notifications = new List<NotificationViewModel>();
 
-            notifications.Add(vm);
-            notifications.Add(vm2);
+               notifications.Add(vm);
+               notifications.Add(vm2);
 
-            return notifications;*/
+               return notifications;*/
         }
 
         private class NotificationRequestModel

--- a/src/JabbR-Core/Hubs/Chat.cs
+++ b/src/JabbR-Core/Hubs/Chat.cs
@@ -280,7 +280,7 @@ namespace JabbR_Core.Hubs
             }
 
             // Add mentions
-            //AddMentions(chatMessage);
+            AddMentions(chatMessage);
 
             //var urls = UrlExtractor.ExtractUrls(chatMessage.Content);
             //if (urls.Count > 0)
@@ -1062,6 +1062,57 @@ namespace JabbR_Core.Hubs
                 // Initialize the chat with the rooms the user is in
                 Clients.Caller.logOn(rooms, privateRooms, user.Preferences);
             }
+        }
+
+        private void AddMentions(ChatMessage message)
+        {
+            var mentionedUsers = new List<ChatUser>();
+            foreach (var userName in MentionExtractor.ExtractMentions(message.Content))
+            {
+                ChatUser mentionedUser = _repository.GetUserByName(userName);
+
+                // Don't create a mention if
+                // 1. If the mentioned user doesn't exist.
+                // 2. If you mention yourself
+                // 3. If you're mentioned in a private room that you don't have access to
+                // 4. You've already been mentioned in this message
+                if (mentionedUser == null ||
+                    mentionedUser == message.UserKeyNavigation ||
+                    (message.RoomKeyNavigation.Private && !mentionedUser.AllowedRooms.Select(r => r.ChatRoomKeyNavigation).Contains(message.RoomKeyNavigation)) ||
+                    mentionedUsers.Contains(mentionedUser))
+                {
+                    continue;
+                }
+
+                // mark as read if ALL of the following
+                // 1. user is not offline
+                // 2. user is not AFK
+                // 3. user is currently in the room
+                bool markAsRead = false;//!mentionedUser.IsAfk
+                                  //&& _repository.IsUserInRoom(_cache, mentionedUser, message.RoomKeyNavigation);
+
+                _chatService.AddNotification(mentionedUser, message, message.RoomKeyNavigation, markAsRead);
+
+                mentionedUsers.Add(mentionedUser);
+            }
+
+            if (mentionedUsers.Count > 0)
+            {
+                _repository.CommitChanges();
+            }
+
+            foreach (var user in mentionedUsers)
+            {
+                UpdateUnreadMentions(user);
+            }
+        }
+
+        private void UpdateUnreadMentions(ChatUser mentionedUser)
+        {
+            var unread = _repository.GetUnreadNotificationsCount(mentionedUser);
+
+            Clients.User(mentionedUser.Id)
+                   .updateUnreadNotifications(unread);
         }
 
     }

--- a/src/JabbR-Core/Services/ChatNotificationService.cs
+++ b/src/JabbR-Core/Services/ChatNotificationService.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Linq;
+using JabbR_Core.Hubs;
+using JabbR_Core.ViewModels;
+using JabbR_Core.Data.Models;
+using JabbR_Core.Data.Repositories;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.AspNetCore.SignalR.Infrastructure;
+
+namespace JabbR_Core.Services
+{
+    public class ChatNotificationService : IChatNotificationService
+    {
+        private readonly IConnectionManager _connectionManager;
+        private readonly IJabbrRepository _repository;
+
+        public ChatNotificationService(IConnectionManager connectionManager)
+        {
+            _connectionManager = connectionManager;
+        }
+
+        public void OnUserNameChanged(ChatUser user, string oldUserName, string newUserName)
+        {
+            // Create the view model
+            var userViewModel = new UserViewModel(user);
+
+            // Tell the user's connected clients that the name changed
+            //var clients = _repository.Clients.Where(c => c.UserId == user.Id).ToList();
+            //foreach (var client in clients)
+            //{
+            //    HubContext.Clients.Client(client.Id).userNameChanged(userViewModel);
+            //}
+
+            // Notify all users in the rooms
+            foreach (var room in user.Rooms.Select(r => r.ChatRoomKeyNavigation).ToList())
+            {
+                HubContext.Clients.Group(room.Name).changeUserName(oldUserName, userViewModel, room.Name);
+            }
+        }
+
+        public void UpdateUnreadMentions(ChatUser mentionedUser, int unread)
+        {
+            foreach (var client in mentionedUser.ConnectedClients)
+            {
+                HubContext.Clients.Client(client.Id).updateUnreadNotifications(unread);
+            }
+        }
+
+        private IHubContext _hubContext;
+        private IHubContext HubContext
+        {
+            get
+            {
+                if (_hubContext == null)
+                {
+                    _hubContext = _connectionManager.GetHubContext<Chat>();
+                }
+
+                return _hubContext;
+            }
+        }
+    }
+}

--- a/src/JabbR-Core/Startup.cs
+++ b/src/JabbR-Core/Startup.cs
@@ -96,6 +96,7 @@ namespace JabbR_Core
             services.AddScoped<ApplicationSettings>();
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             services.AddSingleton<IRecentMessageCache, RecentMessageCache>();
+            services.AddScoped<IChatNotificationService, ChatNotificationService>();
             //services.AddScoped<IMembershipService, MembershipService>();
 
             // Establish default settings from appsettings.json

--- a/src/JabbR-Core/Views/Notifications/_unreadNotifications.cshtml
+++ b/src/JabbR-Core/Views/Notifications/_unreadNotifications.cshtml
@@ -12,7 +12,7 @@
             @if (!notification.Read) { 
             <li data-notification-id="@notification.NotificationKey" class="notification-item @(!notification.Read ? "notification-unread" : "")">
                 
-                    <a href="#" title="@LanguageResources.Notifications_MarkAsRead" class="pull-right js-mark-as-read" data-action-url="@Url.Content("~/notifications/markasread")" data-notification-id="@notification.NotificationKey">
+                    <a href="#" title="@LanguageResources.Notifications_MarkAsRead" class="pull-right js-mark-as-read" id="click" data-action-url="@Url.Content("~/notifications/markasread")" data-notification-id="@notification.NotificationKey">
                         <i class="icon-large icon-ok-circle"></i>
                     </a>
                 
@@ -35,4 +35,3 @@
 {
     <p id="no-notifications" class="well well-large">@LanguageResources.Notifications_NoUnread</p>
 }
-

--- a/src/JabbR-Core/Views/Notifications/index.cshtml
+++ b/src/JabbR-Core/Views/Notifications/index.cshtml
@@ -107,13 +107,16 @@
     <script type="text/javascript" src="~/Scripts/json2.min.js"></script>
     <script type="text/javascript" src="~/Scripts/bootstrap.js"></script>
     <script type="text/javascript" src="~/Scripts/jQuery.tmpl.min.js"></script>
+    <script type="text/javascript" src="~/Scripts/jquery.cookie.js"></script>
     <script type="text/javascript" src="~/Scripts/moment.min.js"></script>
     <script type="text/javascript" src="~/Scripts/ba-linkify.min.js"></script>
     <script type="text/javascript" src="~/Scripts/marked.js"></script>
     <script type="text/javascript" src="~/Scripts/jquery.pubsub.js"></script>
     <script type="text/javascript" src="~/Chat.emoji.js"></script>
+    <script type="text/javascript" src="~/Chat.utility.js"></script>
     <script type="text/javascript" src="~/notifications.unreadcounter.js"></script>
     <script type="text/javascript" src="~/notifications.js"></script>
+    <script src="~/notificationread.js"></script>
     <script src="~/notificationtabs.js"></script>
 </body>
 

--- a/src/JabbR-Core/wwwroot/notifications.js
+++ b/src/JabbR-Core/wwwroot/notifications.js
@@ -12,7 +12,7 @@
             notificationId = $this.data('notificationId');
 
         ev.preventDefault();
-        
+
         if ($this.hasClass('disabled')) {
             return false;
         }


### PR DESCRIPTION
To test:
First, make some notifications by either making fake ones in the database or opening up two browsers as two different users and mention each other in the chat room
Second, Go over to the Notification View, going to the Unread Tab and test Mark As Read by pressing the little check mark next to the notification. The notification should fade away, but still be available in the All Notifications Tab. 
Third, test the Mark All As Read button. All remaining notifications should fade away (but still be available in the All Notifications Tab).

If anything weird is happening.. refresh to see if notification updates occur
