### PR TITLE
adina/UpdateCommand 

### DIFF
--- a/src/JabbR-Core/Commands/UpdateCommand.cs
+++ b/src/JabbR-Core/Commands/UpdateCommand.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using JabbR_Core.Data.Models;
+
+namespace JabbR_Core.Commands
+{
+    [Command("update", "", "", "")]
+    public class UpdateCommand : AdminCommand
+    {
+        public override void ExecuteAdminOperation(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
+        {
+            context.NotificationService.ForceUpdate();
+        }
+    }
+}


### PR DESCRIPTION
Added update command fixing #215. 

To test: Your user must be an Admin, so change isAdmin to True in the database (dbo.AspNetUsers). Then typing /update should pop up a UI message saying the page will refresh in 15 seconds, then refresh the page if not done already. The page should refresh for all users logged in (it did for multiple tabs when I tried). 