### PR TITLE
Adina/gravatar command

### DIFF
--- a/src/JabbR-Core/Commands/GravatarCommand.cs
+++ b/src/JabbR-Core/Commands/GravatarCommand.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.SignalR;
+using System;
+using JabbR_Core.Data.Models;
+using JabbR_Core.Infrastructure;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace JabbR_Core.Commands
+{
+    [Command("gravatar", "Gravatar_CommandInfo", "email", "user")]
+    public class GravatarCommand : UserCommand
+    {
+        public override void Execute(CommandContext context, CallerContext callerContext, ChatUser callingUser, string[] args)
+        {
+            string email = String.Join(" ", args);
+
+            if (String.IsNullOrWhiteSpace(email))
+            {
+                throw new HubException(LanguageResources.Gravatar_EmailRequired);
+            }
+
+            string hash = email.ToLowerInvariant().ToMD5();
+
+            // Set user hash
+            callingUser.Hash = hash;
+
+            context.NotificationService.ChangeGravatar(callingUser);
+
+            context.Repository.CommitChanges();
+        }
+    }
+}

--- a/src/JabbR-Core/Hubs/Chat.cs
+++ b/src/JabbR-Core/Hubs/Chat.cs
@@ -530,10 +530,12 @@ namespace JabbR_Core.Hubs
 
         void INotificationService.ChangeGravatar(ChatUser user)
         {
-            Clients.Caller.hash = user.Hash;
+            //Clients.Caller.hash = user.Hash;
 
             // Update the calling client
             Clients.User(user.Id).gravatarChanged(user.Hash);
+            Clients.Caller.gravatarChanged(user.Hash);
+
 
             // Create the view model
             var userViewModel = new UserViewModel(user);
@@ -542,6 +544,7 @@ namespace JabbR_Core.Hubs
             foreach (var room in user.Rooms.Select(u => u.ChatRoomKeyNavigation))
             {
                 Clients.Group(room.Name).changeGravatar(userViewModel, room.Name);
+                Clients.Caller.changeGravatar(userViewModel, room.Name);
             }
         }
 

--- a/src/JabbR-Core/Views/Account/index.cshtml
+++ b/src/JabbR-Core/Views/Account/index.cshtml
@@ -6,7 +6,7 @@
 
 @{
     var userModel = Model;
-    var gravatar = "https://secure.gravatar.com/avatar/{0}?s=48&d=mm"; //+ userModel.Hash;
+    var gravatar = "https://secure.gravatar.com/avatar/" + userModel.Hash + "?s=48&d=mm";
     var passwordUrl = /*userModel.HasPassword ? Url.Content("~/account/changepassword") : */Url.Content("~/account/newpassword");
 }
 <!DOCTYPE html>


### PR DESCRIPTION
Addresses #228. 
Test changing your gravatar with /gravatar [emailAddress]. There should be a grey text pop-up notifying you you've changed your gravatar, and the change should be visible in your Account settings and in the side bar displaying users in room. 
There is an issue with it displaying your gravatar on recent messages sent in the chatroom, but if you leave and come back it should display your updated gravatar on previously sent messages. It seems like this is a context issue because the client.hash is getting updated in the database for the user.  Will submit bug on backlog. 